### PR TITLE
Improve Speed

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,21 +7,16 @@
 
 'use strict';
 
-module.exports = function flatten(arr) {
+module.exports = function (arr) {
   return flat(arr, []);
 };
 
-function flat(arr, acc) {
+function flat(arr, res) {
+  var i = 0, cur;
   var len = arr.length;
-  var idx = -1;
-
-  while (++idx < len) {
-    var cur = arr[idx];
-    if (Array.isArray(cur)) {
-      flat(cur, acc);
-    } else {
-      acc.push(cur);
-    }
+  for (; i < len; i++) {
+    cur = arr[i];
+    Array.isArray(cur) ? flat(cur, res) : res.push(cur);
   }
-  return acc;
+  return res;
 }


### PR DESCRIPTION
Hey there,

As strange as it may sound, as long as a `len` and `i` are eagerly defined, `for-loops` always outperform `while-loops`.

I was going to release (yet another!) flatten lib, but then I saw that our implementations were nearly the same, so a PR makes more sense 😉 

Here are the benchmarks from my machine --- ran a few times to verify:

```
Benchmarking: (3 of 3)
 · med
 · small-med
 · small

# benchmark/fixtures/med.js (586 bytes)
  arr-flatten-0.1.0 (do-while) x 19,975 ops/sec ±0.17% (95 runs sampled)
  arr-flatten-0.2.0 x 322,662 ops/sec ±0.71% (91 runs sampled)
  arr-flatten-1.0.1 x 336,477 ops/sec ±0.47% (93 runs sampled)
  arr-flatten-mine x 345,996 ops/sec ±0.48% (95 runs sampled)

  fastest is arr-flatten-mine

# benchmark/fixtures/small-med.js (161 bytes)
  arr-flatten-0.1.0 (do-while) x 72,826 ops/sec ±0.58% (95 runs sampled)
  arr-flatten-0.2.0 x 1,265,543 ops/sec ±0.56% (96 runs sampled)
  arr-flatten-1.0.1 x 1,341,199 ops/sec ±0.72% (92 runs sampled)
  arr-flatten-mine x 1,398,921 ops/sec ±0.53% (94 runs sampled)

  fastest is arr-flatten-mine

# benchmark/fixtures/small.js (56 bytes)
  arr-flatten-0.1.0 (do-while) x 384,413 ops/sec ±0.63% (94 runs sampled)
  arr-flatten-0.2.0 x 4,653,617 ops/sec ±0.56% (93 runs sampled)
  arr-flatten-1.0.1 x 4,745,099 ops/sec ±0.56% (94 runs sampled)
  arr-flatten-mine x 4,859,175 ops/sec ±0.53% (95 runs sampled)

  fastest is arr-flatten-mine
```